### PR TITLE
fix nanox environment

### DIFF
--- a/prepare-devenv.sh
+++ b/prepare-devenv.sh
@@ -58,6 +58,11 @@ if [ ! -d dev-env ]; then
     rm nanos-secure-sdk.tar.gz
     mv nanos-secure-sdk* dev-env/SDK/nanos-secure-sdk
 
+    wget https://github.com/LedgerHQ/nanox-secure-sdk/archive/1.3.0.tar.gz -O nanox-secure-sdk.tar.gz
+    tar xf nanox-secure-sdk.tar.gz
+    rm nanox-secure-sdk.tar.gz
+    mv nanox-secure-sdk* dev-env/SDK/nanox-secure-sdk
+
     python3 -m venv dev-env/ledger_py3
     source dev-env/ledger_py3/bin/activate
     pip install wheel
@@ -76,4 +81,5 @@ elif [[ $1 == "s" ]]; then
 elif [[ $1 == "x" ]]; then
     export BOLOS_SDK=$(pwd)/dev-env/SDK/nanox-secure-sdk
     export BOLOS_ENV=$(pwd)/dev-env/CC/nanox
+    export PATH=$(pwd)/dev-env/CC/nanox/clang-arm-fropi/bin:$(pwd)/dev-env/CC/nanox/gcc-arm-none-eabi-5_3-2016q1/bin:$PATH
 fi


### PR DESCRIPTION
- add `nanox` sdk installation
- export `nanox` compilers to `PATH`

`make` commands do not work for `nanox` without the `PATH` fixes.

For some reason `make` works for `nanos` and `blue` without exporting things to `PATH`. But `make` does not work for `nanox`. I am mainly a js dev so not sure whats going on here. Suggested fixes is what helped me building it. Feel free to give feedback and I will change the PR. 