### PR TITLE
SonarCloud: Ignore duplication on test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,10 @@ sonar.sources=.
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
+# Ignore duplication on test files.
+# These files contain raw transaction data, which contains duplicated parts (headers, etc).
+sonar.cpd.exclusions=libsol/*_test.c
+
 sonar.cfamily.threads=1
 sonar.cfamily.cache.enabled=false
 


### PR DESCRIPTION
Some data in test files is duplicated: parts of raw data transaction are similar between various unit tests.

This triggers SonarCloud duplication detection, while this is a standard practice. I suggest removing duplication detection on unit test code.