### PR TITLE
Fix message hash display

### DIFF
--- a/examples/example-sign.js
+++ b/examples/example-sign.js
@@ -25,6 +25,7 @@ const nacl = require("tweetnacl");
 const solana = require("@solana/web3.js");
 const assert = require("assert");
 const isValidUTF8 = require("utf-8-validate");
+const crypto = require("crypto");
 
 const INS_GET_APP_CONFIG = 0x04;
 const INS_GET_PUBKEY = 0x05;
@@ -358,6 +359,9 @@ async function solanaLedgerSignOffchainMessage(
     message: Buffer.from("Тестовое сообщение в формате UTF-8", "utf-8"),
   });
   console.log("Off-chain message:", message);
+  const hash = crypto.createHash("sha256");
+  hash.update(message.serialize());
+  console.log("Expected hash:", bs58.encode(hash.digest()));
 
   sig_bytes = await solanaLedgerSignOffchainMessage(
     transport,

--- a/src/apdu.h
+++ b/src/apdu.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "globals.h"
+#include "sol/parser.h"
 
 typedef enum ApduState {
     ApduStateUninitialized = 0,
@@ -71,6 +72,7 @@ typedef struct ApduCommand {
     bool deprecated_host;
     uint8_t message[MAX_MESSAGE_LENGTH];
     int message_length;
+    Hash message_hash;
 } ApduCommand;
 
 extern ApduCommand G_command;

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -142,15 +142,14 @@ void handle_sign_message_parse_message(volatile unsigned int *tx) {
         if (N_storage.settings.allow_blind_sign == BlindSignEnabled) {
             SummaryItem *item = transaction_summary_primary_item();
             summary_item_set_string(item, "Unrecognized", "format");
-            Hash UnrecognizedMessageHash;
 
             cx_hash_sha256(G_command.message,
                            G_command.message_length,
-                           (uint8_t *) &UnrecognizedMessageHash,
+                           (uint8_t *) &G_command.message_hash,
                            HASH_LENGTH);
 
             item = transaction_summary_general_item();
-            summary_item_set_hash(item, "Message Hash", &UnrecognizedMessageHash);
+            summary_item_set_hash(item, "Message Hash", &G_command.message_hash);
         } else {
             THROW(ApduReplySdkNotSupported);
         }

--- a/src/signOffchainMessage.c
+++ b/src/signOffchainMessage.c
@@ -202,11 +202,10 @@ void handle_sign_offchain_message(volatile unsigned int *flags, volatile unsigne
     }
 
     // compute message hash if needed
-    Hash messageHash;
     if (!is_ascii || N_storage.settings.display_mode == DisplayModeExpert) {
         cx_hash_sha256(G_command.message,
                        G_command.message_length,
-                       (uint8_t *) &messageHash,
+                       (uint8_t *) &G_command.message_hash,
                        HASH_LENGTH);
     }
 
@@ -219,7 +218,7 @@ void handle_sign_offchain_message(volatile unsigned int *flags, volatile unsigne
         summary_item_set_u64(transaction_summary_general_item(), "Version", header.version);
         summary_item_set_u64(transaction_summary_general_item(), "Format", header.format);
         summary_item_set_u64(transaction_summary_general_item(), "Size", header.length);
-        summary_item_set_hash(transaction_summary_general_item(), "Hash", &messageHash);
+        summary_item_set_hash(transaction_summary_general_item(), "Hash", &G_command.message_hash);
 
         Pubkey signer_pubkey;
         get_public_key(signer_pubkey.data,
@@ -227,7 +226,7 @@ void handle_sign_offchain_message(volatile unsigned int *flags, volatile unsigne
                        G_command.derivation_path_length);
         summary_item_set_pubkey(transaction_summary_general_item(), "Signer", &signer_pubkey);
     } else if (!is_ascii) {
-        summary_item_set_hash(transaction_summary_general_item(), "Hash", &messageHash);
+        summary_item_set_hash(transaction_summary_general_item(), "Hash", &G_command.message_hash);
     }
 
     enum SummaryItemKind summary_step_kinds[MAX_TRANSACTION_SUMMARY_ITEMS];

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -136,6 +136,8 @@ fn test_ledger_sign_offchain_message_utf8() -> Result<(), RemoteWalletError> {
             .map_err(|_| {
                 RemoteWalletError::InvalidInput("Failed to serialize message".to_string())
             })?;
+    let hash = solana_sdk::hash::hash(&message);
+    println!("Expected hash: {}", hash);
     let signature = ledger.sign_message(&derivation_path, &message)?;
     assert!(signature.verify(from.as_ref(), &message));
 


### PR DESCRIPTION
message hash was stored in a local variable, while summary_item_set_hash() saves a pointer to the hash to display it later. That led to a dangling pointer and wrong data displayed to the user. This PR introduces message_hash variable in the global state.