### PR TITLE
[fix] Clear memory even on errors

### DIFF
--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -33,6 +33,7 @@ static uint8_t set_result_sign_message() {
             memcpy(G_io_apdu_buffer, signature, SIGNATURE_LENGTH);
         }
         CATCH_OTHER(e) {
+            MEMCLEAR(privateKey);
             THROW(e);
         }
         FINALLY {

--- a/src/signOffchainMessage.c
+++ b/src/signOffchainMessage.c
@@ -97,6 +97,7 @@ static uint8_t set_result_sign_message() {
             memcpy(G_io_apdu_buffer, signature, SIGNATURE_LENGTH);
         }
         CATCH_OTHER(e) {
+            MEMCLEAR(privateKey);
             THROW(e);
         }
         FINALLY {

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,6 +15,7 @@ void get_public_key(uint8_t *publicKeyArray, const uint32_t *derivationPath, siz
             cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
         }
         CATCH_OTHER(e) {
+            MEMCLEAR(privateKey);
             THROW(e);
         }
         FINALLY {
@@ -55,6 +56,7 @@ void get_private_key(cx_ecfp_private_key_t *privateKey,
                                      privateKey);
         }
         CATCH_OTHER(e) {
+            MEMCLEAR(privateKeyData);
             THROW(e);
         }
         FINALLY {
@@ -84,6 +86,7 @@ void get_private_key_with_seed(cx_ecfp_private_key_t *privateKey,
                                      privateKey);
         }
         CATCH_OTHER(e) {
+            MEMCLEAR(privateKeyData);
             THROW(e);
         }
         FINALLY {


### PR DESCRIPTION
In case of a `CATCH_OTHER(e)` containing a `THROW`, the `FINALLY` clause isn't actually executed, so memory should be cleared manually also in this case.