### PR TITLE
fix: Out-of-bounds read when message header signer count exceeds parsed pubkey array

### DIFF
--- a/libsol/parser.c
+++ b/libsol/parser.c
@@ -152,6 +152,13 @@ int parse_offchain_message_application_domain(Parser *parser,
 int parse_message_header(Parser *parser, MessageHeader *header) {
     BAIL_IF(parse_version(parser, header));
     BAIL_IF(parse_pubkeys_header(parser, &header->pubkeys_header));
+    BAIL_IF(header->pubkeys_header.num_required_signatures >
+            header->pubkeys_header.pubkeys_length);
+    BAIL_IF(header->pubkeys_header.num_readonly_signed_accounts >
+            header->pubkeys_header.num_required_signatures);
+    BAIL_IF(header->pubkeys_header.num_readonly_unsigned_accounts >
+            (header->pubkeys_header.pubkeys_length -
+             header->pubkeys_header.num_required_signatures));
     BAIL_IF(
         parse_pubkeys_with_len(parser, header->pubkeys_header.pubkeys_length, &header->pubkeys));
     BAIL_IF(parse_blockhash(parser, &header->blockhash));


### PR DESCRIPTION
Closes #197

## Summary

Automated security fix for **Out-of-bounds read when message header signer count exceeds parsed pubkey array** (High).

**CWE**: CWE-CWE-125
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Added three cross-field validation checks in `parse_message_header()` immediately after `parse_pubkeys_header()` and before `parse_pubkeys_with_len()`:

1. `num_required_signatures <= pubkeys_length` — ensures `scan_header_for_signer()` / `get_pubkey_index()` cannot read beyond the parsed pubkey array
2. `num_readonly_signed_accounts <= num_required_signatures` — ensures the readonly signed count doesn't exceed total signers
3. `num_readonly_unsigned_accounts <= (pubkeys_length - num_required_signatures)` — ensures the readonly unsigned count doesn't exceed total unsigned accounts

This is the minimal fix: a single file change that validates message header invariants at parse time, preventing the out-of-bounds read before any downstream code can use the inconsistent values.

## Caveats
- The subtraction `pubkeys_length - num_required_signatures` is safe because we already verified `num_required_signatures <= pubkeys_length` on the line above.
- This rejects malformed messages at parse time, so any code path that previously accepted such messages (there shouldn't be legitimate ones) will now fail with a parse error.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
