### PR TITLE
fix: Associated Token Account decoder assumes every ATA instruction is Create

### DIFF
--- a/libsol/spl_associated_token_account_instruction.c
+++ b/libsol/spl_associated_token_account_instruction.c
@@ -31,9 +31,28 @@ static int parse_create_spl_associated_token_account_instruction(
 int parse_spl_associated_token_account_instructions(const Instruction *instruction,
                                                     const MessageHeader *header,
                                                     SplAssociatedTokenAccountInfo *info) {
+    if (instruction->data_length == 0) {
+        // Legacy Create instruction with no discriminator
     return parse_create_spl_associated_token_account_instruction(instruction,
                                                                  header,
                                                                  &info->create);
+    }
+
+    Parser parser = {instruction->data, instruction->data_length};
+    uint8_t kind = 0;
+
+    BAIL_IF(parse_u8(&parser, &kind));
+    BAIL_IF(!parser_is_empty(&parser));
+
+    switch (kind) {
+        case 0: /* Create */
+        case 1: /* CreateIdempotent */
+            return parse_create_spl_associated_token_account_instruction(instruction,
+                                                                         header,
+                                                                         &info->create);
+        default:
+            return 1;
+    }
 }
 
 int print_spl_associated_token_account_create_info(const SplAssociatedTokenAccountCreateInfo *info,


### PR DESCRIPTION
Closes #198

## Summary

Automated security fix for **Associated Token Account decoder assumes every ATA instruction is Create** (High).

**CWE**: CWE-CWE-451
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
The ATA instruction parser never validated the instruction discriminator, treating any ATA program invocation as a "Create" instruction. The fix adds discriminator validation:

1. `data_length == 0`: Accepted as legacy Create (the original ATA program used empty data for Create)
2. `data_length == 1, byte == 0`: Create instruction
3. `data_length == 1, byte == 1`: CreateIdempotent instruction (same account layout as Create)
4. Any other data: Rejected (returns error), which will cause the instruction to fall through to blind-signing

This prevents unknown/unsupported ATA instruction variants (like RecoverNested or future additions) from being mislabeled as account creation in clear-signing.

## Caveats
- The legacy Create instruction (data_length == 0) is still accepted for backward compatibility, as existing transactions in the wild use this format.
- Both Create (0) and CreateIdempotent (1) are displayed identically as 'Create token account' since they have the same account layout and semantic meaning for the user. A reviewer may want to differentiate the display text in the future.
- RecoverNested (discriminator 2) is intentionally rejected since it has a different account layout and would need its own parser.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
