### PR TITLE
fix: ATA validation skips bump seed 0 and rejects some valid associated token accounts

### DIFF
--- a/src/ed25519_helpers.c
+++ b/src/ed25519_helpers.c
@@ -127,8 +127,8 @@ bool validate_associated_token_address(const uint8_t owner_account[PUBKEY_LENGTH
     uint8_t nonce = 255;
 
     PRINTF("Trying to validate provided_ata %.*H\n", PUBKEY_LENGTH, provided_ata);
-    while (nonce > 0) {
-        // Worst case scenario is 255 hash + 255 memcmp. The performance hit is not noticeable.
+    do {
+        // Worst case scenario is 256 hash + 256 memcmp. The performance hit is not noticeable.
         if (derivate_ata_candidate(owner_account,
                                    mint_account,
                                    nonce,
@@ -139,7 +139,6 @@ bool validate_associated_token_address(const uint8_t owner_account[PUBKEY_LENGTH
         }
         // Compare the derived ATA with the provided ATA
         PRINTF("derived_ata %.*H with nonce%d\n", PUBKEY_LENGTH, derived_ata, nonce);
-        nonce--;
 
         if (memcmp(derived_ata, provided_ata, PUBKEY_LENGTH) == 0) {
             PRINTF("Successful ATA match\n");
@@ -153,7 +152,7 @@ bool validate_associated_token_address(const uint8_t owner_account[PUBKEY_LENGTH
                 return true;
             }
         }
-    }
+    } while (nonce-- != 0);
 
     // We exhausted all nonces without matching the provided ATA
     PRINTF("ERROR: Unable to find a valid nonce for ATA derivation\n");


### PR DESCRIPTION
Closes #201

## Summary

Automated security fix for **ATA validation skips bump seed 0 and rejects some valid associated token accounts** (Medium).

**CWE**: CWE-CWE-193
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Changed the `while (nonce > 0)` loop to a `do/while (nonce-- != 0)` loop so that bump seed 0 is included in the validation. The original loop tested nonces 255 down to 1 but skipped 0 because the `while (nonce > 0)` condition would fail before nonce 0 was ever derived. The `do/while` pattern ensures all 256 possible bump seeds (255..0) are tested. The `nonce--` is moved to the loop condition (post-decrement after comparison with 0) to avoid uint8_t underflow issues while still covering the full range.

## Caveats
- The nonce decrement was moved from inside the loop body to the while condition. This is functionally equivalent for the iteration range but changes when exactly nonce is decremented relative to the memcmp - however this doesn't matter since the derived_ata buffer (not nonce) is what's being compared.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
