### PR TITLE
fix: Ticker-based dynamic token override can bypass swap mint validation

### DIFF
--- a/src/handle_provide_instruction_descriptor.c
+++ b/src/handle_provide_instruction_descriptor.c
@@ -434,9 +434,13 @@ int validate_instruction_using_descriptor(const MessageHeader *header,
     // Retrieve / calculate the swap validated mint address and recipient address
     // With the current architecture we actually do this step at each instruction but the impact is
     // negligeable
+    // Security: resolve the swap mint from the hardcoded registry only. Host-provided dynamic
+    // token metadata must never be used as the authoritative source of asset identity in swap
+    // validation, otherwise a same-ticker dynamic descriptor could substitute an attacker-chosen
+    // mint for the real one.
     bool is_token_2022_kind;
-    const uint8_t *validated_mint_address = get_token_mint_address(get_swap_ticker(),
-                                                                   &is_token_2022_kind);
+    const uint8_t *validated_mint_address =
+        get_hardcoded_token_mint_address(get_swap_ticker(), &is_token_2022_kind);
     if (validated_mint_address == NULL) {
         PRINTF("Error: no mint address retrieved\n");
         return -1;


### PR DESCRIPTION
## Summary

Automated security fix for **Ticker-based dynamic token override can bypass swap mint validation** (High).

**CWE**: CWE-CWE-807
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Swap instruction validation previously resolved the authoritative mint address via `get_token_mint_address()`, which gives precedence to host-provided (PKI-signed but ticker-keyed) dynamic token metadata over the hardcoded registry. A host able to load a dynamic token descriptor with a colliding ticker could therefore substitute an attacker-chosen mint as the "validated" swap asset, and all subsequent account checks would compare transaction accounts against that attacker mint. Fixed by resolving the swap ticker strictly through the hardcoded registry (`get_hardcoded_token_mint_address`) in `validate_instruction_using_descriptor`, matching the remediation guidance. This eliminates the dynamic-override path for asset identity in swap context while still allowing dynamic token metadata to be used elsewhere for display purposes. Only the single call site is changed; no function signatures or headers are modified.

## Caveats
- Dynamic token metadata is still resolvable outside the swap context (e.g. in display paths via get_dynamic_token_symbol). Only the authoritative swap-mint lookup is hardened, per the remediation guidance.
- get_token_mint_address() remains defined in src/dynamic_token_info.c but is now unreferenced in the app; left in place to keep the patch minimal.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
