### PR TITLE
fix: Out-of-bounds stack write in encode_base58 for inputs longer than 32 bytes

### DIFF
--- a/libsol/printer.c
+++ b/libsol/printer.c
@@ -128,7 +128,7 @@ int encode_base58(const void *in, size_t length, char *out, size_t maxoutlen) {
     uint8_t j;
     size_t start_at;
     size_t zero_count = 0;
-    if (length > sizeof(tmp)) {
+    if (length > (sizeof(buffer) / 2)) {
         return INVALID_PARAMETER;
     }
     memmove(tmp, in, length);


### PR DESCRIPTION
## Summary

Automated security fix for **Out-of-bounds stack write in encode_base58 for inputs longer than 32 bytes** (High).

**CWE**: CWE-CWE-787
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Constrained encode_base58 input length to the safe capacity supported by its 64-byte working buffer. Inputs longer than 32 bytes now return INVALID_PARAMETER before j is initialized beyond the end of the stack buffer, preventing out-of-bounds writes while preserving existing 32-byte pubkey/hash call sites.

## Caveats
- encode_base58 remains limited to 32-byte inputs; callers that intended to encode larger byte arrays must use a larger-workspace implementation instead.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
