### PR TITLE
fix: Composite stake/vote authorize rendering can hide a second target account

### DIFF
--- a/libsol/transaction_printers.c
+++ b/libsol/transaction_printers.c
@@ -354,11 +354,12 @@ static int print_stake_authorize_both(const PrintConfig *print_config,
     // Sanity check
     BAIL_IF(staker_info->authorize != StakeAuthorizeStaker);
     BAIL_IF(withdrawer_info->authorize != StakeAuthorizeWithdrawer);
+    BAIL_IF(!pubkeys_equal(staker_info->account, withdrawer_info->account));
 
     item = transaction_summary_primary_item();
     summary_item_set_pubkey(item, "Set stake auth", staker_info->account);
 
-    if (staker_info->new_authority == withdrawer_info->new_authority) {
+    if (pubkeys_equal(staker_info->new_authority, withdrawer_info->new_authority)) {
         item = transaction_summary_general_item();
         summary_item_set_pubkey(item, "New authorities", staker_info->new_authority);
     } else {
@@ -462,11 +463,12 @@ static int print_vote_authorize_both(const PrintConfig *print_config,
     // Sanity check
     BAIL_IF(voter_info->authorize != VoteAuthorizeVoter);
     BAIL_IF(withdrawer_info->authorize != VoteAuthorizeWithdrawer);
+    BAIL_IF(!pubkeys_equal(voter_info->account, withdrawer_info->account));
 
     item = transaction_summary_primary_item();
     summary_item_set_pubkey(item, "Set vote auth", voter_info->account);
 
-    if (voter_info->new_authority == withdrawer_info->new_authority) {
+    if (pubkeys_equal(voter_info->new_authority, withdrawer_info->new_authority)) {
         item = transaction_summary_general_item();
         summary_item_set_pubkey(item, "New authorities", voter_info->new_authority);
     } else {


### PR DESCRIPTION
## Summary

Automated security fix for **Composite stake/vote authorize rendering can hide a second target account** (High).

**CWE**: CWE-CWE-451
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Added same-account validation before rendering the composite stake and vote authorize summaries, so mismatched authorize instructions can no longer be collapsed into a UI that shows only the first account. Also switched the composite new-authority equality checks to compare pubkey values rather than pointer identity.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
